### PR TITLE
Raise an error on missing rules

### DIFF
--- a/lib/voxpop/non_terminal.ex
+++ b/lib/voxpop/non_terminal.ex
@@ -5,6 +5,8 @@ end
 
 defimpl Voxpop.Production, for: Voxpop.NonTerminal do
   def evaluate(non_terminal, registry) do
-    registry.rules |> Map.get(non_terminal.rule) |> Voxpop.Production.evaluate(registry)
+    registry.rules
+    |> Map.get(non_terminal.rule, %Voxpop.Terminal{atom: "<missing rule `#{non_terminal.rule}`>"})
+    |> Voxpop.Production.evaluate(registry)
   end
 end

--- a/lib/voxpop/non_terminal.ex
+++ b/lib/voxpop/non_terminal.ex
@@ -5,8 +5,12 @@ end
 
 defimpl Voxpop.Production, for: Voxpop.NonTerminal do
   def evaluate(non_terminal, registry) do
-    registry.rules
-    |> Map.get(non_terminal.rule, %Voxpop.Terminal{atom: "<missing rule `#{non_terminal.rule}`>"})
-    |> Voxpop.Production.evaluate(registry)
+    value = Map.get(registry.rules, non_terminal.rule)
+
+    if value do
+      Voxpop.Production.evaluate(value, registry)
+    else
+      raise "Invalid rule: `#{non_terminal.rule}`"
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,9 +7,9 @@ defmodule Voxpop.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
-     package: package,
-     description: description
+     deps: deps(),
+     package: package(),
+     description: description()
     ]
   end
 

--- a/test/voxpop_test.exs
+++ b/test/voxpop_test.exs
@@ -24,6 +24,8 @@ defmodule VoxpopTest do
 
   test "gracefully handles missing rules" do
     concat_grammar = %Voxpop.Grammar.Definition{start: "{greeting} world", rules: %{greeting: "Hello {invalid}"}}
-    assert Voxpop.generate(concat_grammar) == "Hello "
+    assert_raise RuntimeError, "Invalid rule: `invalid`", fn ->
+      Voxpop.generate(concat_grammar)
+    end
   end
 end

--- a/test/voxpop_test.exs
+++ b/test/voxpop_test.exs
@@ -21,4 +21,9 @@ defmodule VoxpopTest do
     concat_grammar = %Voxpop.Grammar.Definition{start: "{greeting} world", rules: %{greeting: "Hello"}}
     assert Voxpop.generate(concat_grammar) == "Hello world"
   end
+
+  test "gracefully handles missing rules" do
+    concat_grammar = %Voxpop.Grammar.Definition{start: "{greeting} world", rules: %{greeting: "Hello {invalid}"}}
+    assert Voxpop.generate(concat_grammar) == "Hello "
+  end
 end


### PR DESCRIPTION
Fixes a missing protocol issue when rules are not provided:

```
** (Protocol.UndefinedError) protocol Voxpop.Production not implemented for nil. This protocol is implemented for: Voxpop.Choice, Voxpop.Concat, Voxpop.NonTerminal, Voxpop.Terminal
```